### PR TITLE
Dispatch `stamped` event as Juicy/juicy-html does

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ To provide a state before element is upgraded, please use attributes.
 
 ## Events
 
-Name       | Detail                                     | Description
----        | ---                                        | ---
-`stamped`  | *Array* of *Node* s array of stamped nodes | Trigger every time content is (re-)stamped
-`stamping` | *DocumentFragment*	fragment being stamped  | Called just before stamping the fragment
+Name       | When                               | `event.detail`
+---        | ---                                | ---
+`stamped`  | Every time content is (re-)stamped | *Array* of stamped *Node* s
+`stamping` | Just before stamping the fragment  | *DocumentFragment*	being stamped
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ To provide a state before element is upgraded, please use attributes.
 
 Name       | Detail                                     | Description
 ---        | ---                                        | ---
+`stamped`  | *Array* of *Node* s array of stamped nodes | Trigger every time content is (re-)stamped
 `stamping` | *DocumentFragment*	fragment being stamped  | Called just before stamping the fragment
 
 ### Dependencies

--- a/imported-template.html
+++ b/imported-template.html
@@ -145,6 +145,9 @@ https://github.com/Juicy/imported-template
             // TODO(tomalec): check if it's still required
             setTimeout(function appendAsync() {
                 document.head.appendChild(link);
+                that.dispatchEvent(new CustomEvent("stamped", {
+                    detail: that.stampedNodes
+                }));
             });
             return this;
         };


### PR DESCRIPTION
We need tests for this, but they should be added in `juicy-html` repo first https://github.com/Juicy/juicy-html/issues/33