### PR TITLE
Fix pending flag resetting

### DIFF
--- a/imported-template.html
+++ b/imported-template.html
@@ -139,7 +139,7 @@ https://github.com/Juicy/imported-template
                     //   HTMLImports.parser.addElementToDocument = originalAddElementToDocument;
                 }
 
-                this.pending = false;
+                that.pending = false;
             };
             // guessed workaround for StarcounterSamples/Launcher#82, Polymer/polymer#554, http://crbug.com/389566
             // TODO(tomalec): check if it's still required


### PR DESCRIPTION
So far we have no tests for `pending` and I'm not sure whether it should be public API. 

However, right now it's polluting  `link` element, as it's setting `.pending` property on it.