### PR TITLE
Compatibility fix for hybrid views for Polymer 1 and 2

### DIFF
--- a/imported-template.html
+++ b/imported-template.html
@@ -169,9 +169,16 @@ https://github.com/Juicy/imported-template
         }
 
         function _notifyNodes(path, value, nodes) {
-            for (var childNo = 0; childNo < nodes.length; childNo++) {
-                if (nodes[childNo]._notifyPath) {
-                    nodes[childNo]._notifyPath(path, value);
+            for (let childNo = 0; childNo < nodes.length; childNo++) {
+                const elem = nodes[childNo];
+                if (elem._notifyPath) {
+                    elem._notifyPath(path, value);
+                }
+
+                //mirrored implementation of this fix: https://github.com/Polymer/polymer/pull/4537/files
+                const firstElemChild = elem.firstElementChild;
+                if (firstElemChild && firstElemChild.getAttribute("is") === elem.localName && firstElemChild._notifyPath) {
+                    firstElemChild._notifyPath(path, value);
                 }
             }
         }

--- a/test/use-cases/dom-bind/notify-dom-bind.html
+++ b/test/use-cases/dom-bind/notify-dom-bind.html
@@ -20,10 +20,10 @@
         <template>
             <div>
                 <h1>outside dom-bind</h1>
-                <template is="dom-bind" id="externalDomBind">
+                <dom-bind><template is="dom-bind" id="externalDomBind">
                     <div>inside dom-bind</div>
                     <template is="imported-template" model="{{model}}" content="./notify-dom-bind.import.html"></template>
-                </template>
+                </template></dom-bind>
             </div>
         </template>
     </test-fixture>

--- a/test/use-cases/dom-bind/notify-dom-bind.import.html
+++ b/test/use-cases/dom-bind/notify-dom-bind.import.html
@@ -1,16 +1,16 @@
 <imported-template-scope scope="MyVendorName">
     <template>
-        <template is="dom-bind" id="internalDomBindScoped">
+        <dom-bind><template is="dom-bind" id="internalDomBindScoped">
             <div>notify-dom-bind.import.html
                 <span id="internalSpanScoped">{{model.works}}</span>
             </div>
-        </template>
+        </template></dom-bind>
     </template>
 </imported-template-scope>
 <template>
-    <template is="dom-bind" id="internalDomBind">
+    <dom-bind><template is="dom-bind" id="internalDomBind">
         <div>notify-dom-bind.import.html
             <span id="internalSpan">{{model.works}}</span>
         </div>
-    </template>
+    </template></dom-bind>
 </template>


### PR DESCRIPTION
Problem: `imported-template` does not forward notifications to `<template is="dom-bind">` if it is wrapped in `<dom-bind>`. This makes it impossible to have hybrid views for Polymer 1 and 2

Solution: apply the mirrored version of the Polymer's own solution for this problem: https://github.com/Polymer/polymer/pull/4537/files

This was discussed in starcounter.slack.com/archives/C5PEXSXQE/p1513614571000221

Requires https://github.com/Juicy/juicy-html/pull/37, otherwise the tests fail.