### PR TITLE
Workaround HTML Imports bug that blocks imported `link rel="stylesheet"`s in IE/Edge,

### DIFF
--- a/imported-template.html
+++ b/imported-template.html
@@ -67,8 +67,8 @@ https://github.com/Juicy/imported-template
                             if(isIE){
                                 stripDisabledType(singleFragment);
                             }
-                            // convert dynamic NodeList to regullar array
-                            nodes = Array.prototype.slice.call(singleFragment.childNodes);
+                            // convert dynamic NodeList to regular array
+                            nodes = Array.from(singleFragment.childNodes);
                             if (singleTemplate.parentElement.tagName === "IMPORTED-TEMPLATE-SCOPE") {
                                 nodes.scope = singleTemplate.parentElement.getAttribute("scope");
                                 that.scopedNodes.push(nodes);
@@ -89,8 +89,8 @@ https://github.com/Juicy/imported-template
                     }
 
 
-                    // convert dynamic NodeList to regullar array
-                    that.stampedNodes = Array.prototype.slice.call(fragment.childNodes);
+                    // convert dynamic NodeList to regular array
+                    that.stampedNodes = Array.from(fragment.childNodes);
                     // dispatch event before stamping
                     that.dispatchEvent(new CustomEvent('stamping', {detail: fragment}));
                     // attach models

--- a/imported-template.html
+++ b/imported-template.html
@@ -7,6 +7,16 @@ https://github.com/Juicy/imported-template
 <link rel="import" href="../juicy-html/juicy-html.html">
 <script>
     (function () {
+        // Needed to workaround https://github.com/webcomponents/webcomponentsjs/issues/1008
+        const isIE = /Trident/.test(navigator.userAgent) ||
+                    /Edge\/\d./i.test(navigator.userAgent);
+        const importDisableType = 'import-disable';
+        const stripDisabledType = function(template) {
+            const scope = template.content || template;
+            scope.querySelectorAll(`link[type="${importDisableType}"]`)
+                .forEach((link)=>{link.removeAttribute('type')});
+            scope.querySelectorAll('template').forEach(stripDisabledType);
+        };
         class ImportedTemplate extends customElements.get('juicy-html') {
             constructor(self) {
                 self = super(self);
@@ -54,6 +64,9 @@ https://github.com/Juicy/imported-template
                             singleTemplate = templates[nodeNo];
                             //d debugger // or innerHTML in this case
                             singleFragment = document.importNode(singleTemplate.content, true);
+                            if(isIE){
+                                stripDisabledType(singleFragment);
+                            }
                             // convert dynamic NodeList to regullar array
                             nodes = Array.prototype.slice.call(singleFragment.childNodes);
                             if (singleTemplate.parentElement.tagName === "IMPORTED-TEMPLATE-SCOPE") {

--- a/test/index.html
+++ b/test/index.html
@@ -31,7 +31,8 @@
             'use-cases/dom-bind/dom-bind.html',
             'use-cases/dom-bind/dom-repeat.html',
             'use-cases/dom-bind/notify-dom-bind.html',
-            'use-cases/chromiumBugs.html'
+            'use-cases/chromiumBugs.html',
+            'use-cases/HTMLImportsIEBug.html'
         ]);
     </script>
 </body>

--- a/test/mock/nested-style.css
+++ b/test/mock/nested-style.css
@@ -1,3 +1,3 @@
-#nested-green{
-    color: rgb(0, 128, 0);
+#nested-blue{
+    color: rgb(0, 0, 128);
 }

--- a/test/mock/nested-style.css
+++ b/test/mock/nested-style.css
@@ -1,0 +1,3 @@
+#nested-green{
+    color: rgb(0, 128, 0);
+}

--- a/test/mock/style.css
+++ b/test/mock/style.css
@@ -1,0 +1,3 @@
+#green{
+    color: rgb(0, 128, 0);
+}

--- a/test/mock/with-link-stylesheets.html
+++ b/test/mock/with-link-stylesheets.html
@@ -3,6 +3,6 @@
     <div id="green">smth</div>
     <template id="nested">
         <link id="imported-nested-styles" rel="stylesheet" href="../mock/nested-style.css">
-        <div id="nested-green">smth</div>
+        <div id="nested-blue">smth</div>
     </template>
 </template>

--- a/test/mock/with-link-stylesheets.html
+++ b/test/mock/with-link-stylesheets.html
@@ -1,0 +1,8 @@
+<template>
+    <link id="imported-styles" rel="stylesheet" href="../mock/style.css">
+    <div id="green">smth</div>
+    <template id="nested">
+        <link id="imported-nested-styles" rel="stylesheet" href="../mock/nested-style.css">
+        <div id="nested-green">smth</div>
+    </template>
+</template>

--- a/test/use-cases/HTMLImportsIEBug.html
+++ b/test/use-cases/HTMLImportsIEBug.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../../web-component-tester/browser.js"></script>
+
+    <!-- Step 1: import the element to test -->
+    <link rel="import" href="../../imported-template.html">
+</head>
+
+<body>
+
+    <div id="other-element">foo</div>
+    <!-- You can use the document as a place to set up your fixtures. -->
+    <test-fixture id="imported-template-fixture">
+        <template>
+            <div>
+                <!-- nest to workaround test-fixture bug -->
+                <imported-template href="../mock/with-link-stylesheets.html">
+                </imported-template>
+            </div>
+        </template>
+    </test-fixture>
+
+    <script>
+        describe('when <imported-template> is connected, and imports a template', function() {
+            var myElContainer;
+            beforeEach(function() {
+                myElContainer = fixture('imported-template-fixture');
+            });
+
+            context('with a link element,', function() {
+                it('the link element should eventually be stamped, load and apply styles', function(done){
+                    setTimeout(()=>{
+                        const importedStyles = myElContainer.querySelector('#imported-styles');
+                        const styledElement = myElContainer.querySelector('#green');
+
+                        expect(importedStyles).to.be.ok;
+                        expect(importedStyles.sheet).to.be.ok;
+                        expect(importedStyles.sheet.cssRules).to.have.lengthOf(1);
+                        expect(window.getComputedStyle(styledElement)).to.have.property('color', 'rgb(0, 128, 0)');
+                        done();
+                    }, 100);
+                });
+            });
+            context('that contains a nested template with a link element, once nested template is manually attached to document', function() {
+
+                beforeEach(function(done) {
+                    setTimeout(()=>{
+                        const nestedTemplate = myElContainer.querySelector('#nested');
+                        myElContainer.appendChild(document.importNode(nestedTemplate.content, true));
+                        done();
+                    }, 10);
+                });
+                it('the nested link element should eventually be stamped, load and apply styles', function(done){
+                    setTimeout(()=>{
+                        const importedStyles = myElContainer.querySelector('#imported-nested-styles');
+                        const styledElement = myElContainer.querySelector('#nested-green');
+
+                        expect(importedStyles).to.be.ok;
+                        expect(importedStyles.sheet).to.be.ok;
+                        expect(importedStyles.sheet.cssRules).to.have.lengthOf(1);
+                        expect(window.getComputedStyle(styledElement)).to.have.property('color', 'rgb(0, 128, 0)');
+                        done();
+                    }, 100);
+                });
+            });
+        });
+    </script>
+
+</body>
+
+</html>

--- a/test/use-cases/HTMLImportsIEBug.html
+++ b/test/use-cases/HTMLImportsIEBug.html
@@ -59,12 +59,12 @@
                 it('the nested link element should eventually be stamped, load and apply styles', function(done){
                     setTimeout(()=>{
                         const importedStyles = myElContainer.querySelector('#imported-nested-styles');
-                        const styledElement = myElContainer.querySelector('#nested-green');
+                        const styledElement = myElContainer.querySelector('#nested-blue');
 
                         expect(importedStyles).to.be.ok;
                         expect(importedStyles.sheet).to.be.ok;
                         expect(importedStyles.sheet.cssRules).to.have.lengthOf(1);
-                        expect(window.getComputedStyle(styledElement)).to.have.property('color', 'rgb(0, 128, 0)');
+                        expect(window.getComputedStyle(styledElement)).to.have.property('color', 'rgb(0, 0, 128)');
                         done();
                     }, 500);
                 });

--- a/test/use-cases/HTMLImportsIEBug.html
+++ b/test/use-cases/HTMLImportsIEBug.html
@@ -44,7 +44,7 @@
                         expect(importedStyles.sheet.cssRules).to.have.lengthOf(1);
                         expect(window.getComputedStyle(styledElement)).to.have.property('color', 'rgb(0, 128, 0)');
                         done();
-                    }, 100);
+                    }, 500);
                 });
             });
             context('that contains a nested template with a link element, once nested template is manually attached to document', function() {
@@ -54,7 +54,7 @@
                         const nestedTemplate = myElContainer.querySelector('#nested');
                         myElContainer.appendChild(document.importNode(nestedTemplate.content, true));
                         done();
-                    }, 10);
+                    }, 500);
                 });
                 it('the nested link element should eventually be stamped, load and apply styles', function(done){
                     setTimeout(()=>{
@@ -66,7 +66,7 @@
                         expect(importedStyles.sheet.cssRules).to.have.lengthOf(1);
                         expect(window.getComputedStyle(styledElement)).to.have.property('color', 'rgb(0, 128, 0)');
                         done();
-                    }, 100);
+                    }, 500);
                 });
             });
         });


### PR DESCRIPTION
Remove `type="import-disable"` attribute of stamped links, clean all templates recursively,
https://github.com/webcomponents/webcomponentsjs/issues/1008

https://github.com/Starcounter/uniform.css/issues/63